### PR TITLE
Button core component tests

### DIFF
--- a/aem65/src/main/java/com/cognifide/qa/bb/aem65/tests/pageobjects/corecomponents/ButtonComponent.java
+++ b/aem65/src/main/java/com/cognifide/qa/bb/aem65/tests/pageobjects/corecomponents/ButtonComponent.java
@@ -10,31 +10,31 @@ import org.openqa.selenium.support.FindBy;
 @PageObject(css = ".cmp-button")
 public class ButtonComponent {
 
-    @Inject
-    @CurrentScope
-    private WebElement component;
+  private static final String ARIA_LABEL = "aria-label";
 
-    @FindBy(css = ".cmp-button__text")
-    private WebElement text;
+  @Inject
+  @CurrentScope
+  private WebElement component;
 
-    @FindBy(css = ".cmp-button__icon")
-    private WebElement icon;
+  @FindBy(css = ".cmp-button__text")
+  private WebElement text;
 
-    private static final String ARIA_LABEL = "aria-label";
+  @FindBy(css = ".cmp-button__icon")
+  private WebElement icon;
 
-    public String getText() {
-        return text.getText();
-    }
+  public String getText() {
+    return text.getText();
+  }
 
-    public String getLink() {
-        return component.getAttribute(HtmlTags.Attributes.HREF);
-    }
+  public String getLink() {
+    return component.getAttribute(HtmlTags.Attributes.HREF);
+  }
 
-    public String getIconClasses() {
-        return icon.getAttribute(HtmlTags.Attributes.CLASS);
-    }
+  public String getIconClasses() {
+    return icon.getAttribute(HtmlTags.Attributes.CLASS);
+  }
 
-    public String getAriaLabel() {
-        return component.getAttribute(ARIA_LABEL);
-    }
+  public String getAriaLabel() {
+    return component.getAttribute(ARIA_LABEL);
+  }
 }

--- a/aem65/src/main/java/com/cognifide/qa/bb/aem65/tests/pageobjects/corecomponents/ButtonComponent.java
+++ b/aem65/src/main/java/com/cognifide/qa/bb/aem65/tests/pageobjects/corecomponents/ButtonComponent.java
@@ -1,0 +1,40 @@
+package com.cognifide.qa.bb.aem65.tests.pageobjects.corecomponents;
+
+import com.cognifide.qa.bb.constants.HtmlTags;
+import com.cognifide.qa.bb.qualifier.CurrentScope;
+import com.cognifide.qa.bb.qualifier.PageObject;
+import com.google.inject.Inject;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+@PageObject(css = ".cmp-button")
+public class ButtonComponent {
+
+    @Inject
+    @CurrentScope
+    private WebElement component;
+
+    @FindBy(css = ".cmp-button__text")
+    private WebElement text;
+
+    @FindBy(css = ".cmp-button__icon")
+    private WebElement icon;
+
+    private static final String ARIA_LABEL = "aria-label";
+
+    public String getText() {
+        return text.getText();
+    }
+
+    public String getLink() {
+        return component.getAttribute(HtmlTags.Attributes.HREF);
+    }
+
+    public String getIconClasses() {
+        return icon.getAttribute(HtmlTags.Attributes.CLASS);
+    }
+
+    public String getAriaLabel() {
+        return component.getAttribute(ARIA_LABEL);
+    }
+}

--- a/aem65/src/test/java/com/cognifide/qa/bb/aem65/tests/corecomponents/ButtonComponentTest.java
+++ b/aem65/src/test/java/com/cognifide/qa/bb/aem65/tests/corecomponents/ButtonComponentTest.java
@@ -1,0 +1,99 @@
+package com.cognifide.qa.bb.aem65.tests.corecomponents;
+
+import com.cognifide.qa.bb.aem.core.api.AemActions;
+import com.cognifide.qa.bb.aem.core.component.actions.ConfigureComponentData;
+import com.cognifide.qa.bb.aem.core.component.configuration.ResourceFileLocation;
+import com.cognifide.qa.bb.aem.core.pages.sling.SlingDataXMLBuilder;
+import com.cognifide.qa.bb.aem.core.pages.sling.SlingPageData;
+import com.cognifide.qa.bb.aem65.tests.AbstractAemAuthorTest;
+import com.cognifide.qa.bb.aem65.tests.pageobjects.corecomponents.ButtonComponent;
+import com.cognifide.qa.bb.aem65.tests.pages.TestPage;
+import com.cognifide.qa.bb.api.actions.ActionException;
+import com.cognifide.qa.bb.junit5.guice.Modules;
+import com.cognifide.qa.bb.modules.BobcatRunModule;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Feature;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * These tests verify if Bobcat can handle the configuration of the Button Component
+ * https://opensource.adobe.com/aem-core-wcm-components/library/button.html
+ */
+@Modules(BobcatRunModule.class)
+@Epic("Core Components authoring tests")
+@Feature("Button Component configuration")
+@DisplayName("Author can configure for Button Component the...")
+public class ButtonComponentTest extends AbstractAemAuthorTest {
+
+    private static final String TEST_PAGE_PATH = "/content/core-components-examples/library/button-component-test-page";
+
+    private TestPage page;
+    private ButtonComponent component;
+
+    @BeforeEach
+    public void createAndOpenTestPage() throws ActionException {
+        controller.execute(AemActions.CREATE_PAGE_VIA_SLING, new SlingPageData(TEST_PAGE_PATH,
+                SlingDataXMLBuilder.buildFromFile(
+                        "testpages/core-components/buttonComponentTestPage.xml")));
+        page = bobcatPageFactory.create("/editor.html" + TEST_PAGE_PATH + ".html", TestPage.class);
+        page.open();
+    }
+
+    @Test
+    @DisplayName("text")
+    public void configureText() throws ActionException {
+        controller.execute(AemActions.CONFIGURE_COMPONENT,
+                new ConfigureComponentData("container", "Button (v1)", 0,
+                        new ResourceFileLocation("component-configs/core-components/button/text.yaml")));
+        component = page.getContent(ButtonComponent.class, 0);
+        assertThat(component.getText())
+                .as("Check if the text is configured")
+                .isEqualTo("Custom button text");
+    }
+
+    @Test
+    @DisplayName("link")
+    public void configureLink() throws ActionException {
+        controller.execute(AemActions.CONFIGURE_COMPONENT,
+                new ConfigureComponentData("container", "Button (v1)", 0,
+                        new ResourceFileLocation("component-configs/core-components/button/link.yaml")));
+        component = page.getContent(ButtonComponent.class, 0);
+        assertThat(component.getLink())
+                .as("Check if the link is configured")
+                .endsWith("/content/we-retail/us/en.html");
+    }
+
+    @Test
+    @DisplayName("icon")
+    public void configureIcon() throws ActionException {
+        controller.execute(AemActions.CONFIGURE_COMPONENT,
+                new ConfigureComponentData("container", "Button (v1)", 0,
+                        new ResourceFileLocation("component-configs/core-components/button/icon.yaml")));
+        component = page.getContent(ButtonComponent.class, 0);
+        assertThat(component.getIconClasses())
+                .as("Check if the icon is configured")
+                .matches(".*cmp-button__icon--email.*");
+    }
+
+    @Test
+    @DisplayName("aria label")
+    public void configureLabel() throws ActionException {
+        controller.execute(AemActions.CONFIGURE_COMPONENT,
+                new ConfigureComponentData("container", "Button (v1)", 0,
+                        new ResourceFileLocation("component-configs/core-components/button/label.yaml")));
+        component = page.getContent(ButtonComponent.class, 0);
+        assertThat(component.getAriaLabel())
+                .as("Check if the label is configured")
+                .isEqualTo("Custom aria label");
+    }
+
+    @AfterEach
+    public void deleteTestPage() throws ActionException {
+        controller.execute(AemActions.DELETE_PAGE_VIA_SLING, new SlingPageData(TEST_PAGE_PATH));
+    }
+}

--- a/aem65/src/test/java/com/cognifide/qa/bb/aem65/tests/corecomponents/ButtonComponentTest.java
+++ b/aem65/src/test/java/com/cognifide/qa/bb/aem65/tests/corecomponents/ButtonComponentTest.java
@@ -30,70 +30,70 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("Author can configure for Button Component the...")
 public class ButtonComponentTest extends AbstractAemAuthorTest {
 
-    private static final String TEST_PAGE_PATH = "/content/core-components-examples/library/button-component-test-page";
+  private static final String TEST_PAGE_PATH = "/content/core-components-examples/library/button-component-test-page";
 
-    private TestPage page;
-    private ButtonComponent component;
+  private TestPage page;
+  private ButtonComponent component;
 
-    @BeforeEach
-    public void createAndOpenTestPage() throws ActionException {
-        controller.execute(AemActions.CREATE_PAGE_VIA_SLING, new SlingPageData(TEST_PAGE_PATH,
-                SlingDataXMLBuilder.buildFromFile(
-                        "testpages/core-components/buttonComponentTestPage.xml")));
-        page = bobcatPageFactory.create("/editor.html" + TEST_PAGE_PATH + ".html", TestPage.class);
-        page.open();
-    }
+  @BeforeEach
+  public void createAndOpenTestPage() throws ActionException {
+    controller.execute(AemActions.CREATE_PAGE_VIA_SLING, new SlingPageData(TEST_PAGE_PATH,
+        SlingDataXMLBuilder.buildFromFile(
+            "testpages/core-components/buttonComponentTestPage.xml")));
+    page = bobcatPageFactory.create("/editor.html" + TEST_PAGE_PATH + ".html", TestPage.class);
+    page.open();
+  }
 
-    @Test
-    @DisplayName("text")
-    public void configureText() throws ActionException {
-        controller.execute(AemActions.CONFIGURE_COMPONENT,
-                new ConfigureComponentData("container", "Button (v1)", 0,
-                        new ResourceFileLocation("component-configs/core-components/button/text.yaml")));
-        component = page.getContent(ButtonComponent.class, 0);
-        assertThat(component.getText())
-                .as("Check if the text is configured")
-                .isEqualTo("Custom button text");
-    }
+  @Test
+  @DisplayName("text")
+  public void configureText() throws ActionException {
+    controller.execute(AemActions.CONFIGURE_COMPONENT,
+        new ConfigureComponentData("container", "Button (v1)", 0,
+            new ResourceFileLocation("component-configs/core-components/button/text.yaml")));
+    component = page.getContent(ButtonComponent.class, 0);
+    assertThat(component.getText())
+        .as("Check if the text is configured")
+        .isEqualTo("Custom button text");
+  }
 
-    @Test
-    @DisplayName("link")
-    public void configureLink() throws ActionException {
-        controller.execute(AemActions.CONFIGURE_COMPONENT,
-                new ConfigureComponentData("container", "Button (v1)", 0,
-                        new ResourceFileLocation("component-configs/core-components/button/link.yaml")));
-        component = page.getContent(ButtonComponent.class, 0);
-        assertThat(component.getLink())
-                .as("Check if the link is configured")
-                .endsWith("/content/we-retail/us/en.html");
-    }
+  @Test
+  @DisplayName("link")
+  public void configureLink() throws ActionException {
+    controller.execute(AemActions.CONFIGURE_COMPONENT,
+        new ConfigureComponentData("container", "Button (v1)", 0,
+            new ResourceFileLocation("component-configs/core-components/button/link.yaml")));
+    component = page.getContent(ButtonComponent.class, 0);
+    assertThat(component.getLink())
+        .as("Check if the link is configured")
+        .endsWith("/content/we-retail/us/en.html");
+  }
 
-    @Test
-    @DisplayName("icon")
-    public void configureIcon() throws ActionException {
-        controller.execute(AemActions.CONFIGURE_COMPONENT,
-                new ConfigureComponentData("container", "Button (v1)", 0,
-                        new ResourceFileLocation("component-configs/core-components/button/icon.yaml")));
-        component = page.getContent(ButtonComponent.class, 0);
-        assertThat(component.getIconClasses())
-                .as("Check if the icon is configured")
-                .matches(".*cmp-button__icon--email.*");
-    }
+  @Test
+  @DisplayName("icon")
+  public void configureIcon() throws ActionException {
+    controller.execute(AemActions.CONFIGURE_COMPONENT,
+        new ConfigureComponentData("container", "Button (v1)", 0,
+            new ResourceFileLocation("component-configs/core-components/button/icon.yaml")));
+    component = page.getContent(ButtonComponent.class, 0);
+    assertThat(component.getIconClasses())
+        .as("Check if the icon is configured")
+        .matches(".*cmp-button__icon--email.*");
+  }
 
-    @Test
-    @DisplayName("aria label")
-    public void configureLabel() throws ActionException {
-        controller.execute(AemActions.CONFIGURE_COMPONENT,
-                new ConfigureComponentData("container", "Button (v1)", 0,
-                        new ResourceFileLocation("component-configs/core-components/button/label.yaml")));
-        component = page.getContent(ButtonComponent.class, 0);
-        assertThat(component.getAriaLabel())
-                .as("Check if the label is configured")
-                .isEqualTo("Custom aria label");
-    }
+  @Test
+  @DisplayName("aria label")
+  public void configureLabel() throws ActionException {
+    controller.execute(AemActions.CONFIGURE_COMPONENT,
+        new ConfigureComponentData("container", "Button (v1)", 0,
+            new ResourceFileLocation("component-configs/core-components/button/label.yaml")));
+    component = page.getContent(ButtonComponent.class, 0);
+    assertThat(component.getAriaLabel())
+        .as("Check if the label is configured")
+        .isEqualTo("Custom aria label");
+  }
 
-    @AfterEach
-    public void deleteTestPage() throws ActionException {
-        controller.execute(AemActions.DELETE_PAGE_VIA_SLING, new SlingPageData(TEST_PAGE_PATH));
-    }
+  @AfterEach
+  public void deleteTestPage() throws ActionException {
+    controller.execute(AemActions.DELETE_PAGE_VIA_SLING, new SlingPageData(TEST_PAGE_PATH));
+  }
 }

--- a/aem65/src/test/resources/component-configs/core-components/button/icon.yaml
+++ b/aem65/src/test/resources/component-configs/core-components/button/icon.yaml
@@ -1,0 +1,7 @@
+Properties:
+  - label: Text
+    type: TEXTFIELD
+    value: Custom button text
+  - label: Icon
+    type: TEXTFIELD
+    value: email

--- a/aem65/src/test/resources/component-configs/core-components/button/label.yaml
+++ b/aem65/src/test/resources/component-configs/core-components/button/label.yaml
@@ -1,0 +1,8 @@
+Properties:
+  - label: Text
+    type: TEXTFIELD
+    value: Custom button text
+Accessibility:
+  - label: Label
+    type: TEXTFIELD
+    value: Custom aria label

--- a/aem65/src/test/resources/component-configs/core-components/button/link.yaml
+++ b/aem65/src/test/resources/component-configs/core-components/button/link.yaml
@@ -1,0 +1,7 @@
+Properties:
+  - label: Text
+    type: TEXTFIELD
+    value: Custom link button text
+  - label: Link
+    type: PATHBROWSER
+    value: /content/we-retail/us/en

--- a/aem65/src/test/resources/component-configs/core-components/button/text.yaml
+++ b/aem65/src/test/resources/component-configs/core-components/button/text.yaml
@@ -1,0 +1,4 @@
+Properties:
+  - label: Text
+    type: TEXTFIELD
+    value: Custom button text

--- a/aem65/src/test/resources/testpages/core-components/buttonComponentTestPage.xml
+++ b/aem65/src/test/resources/testpages/core-components/buttonComponentTestPage.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
-          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-          jcr:primaryType="cq:Page">
-    <jcr:content
-            cq:template="/conf/core-components-examples/settings/wcm/templates/content-page"
-            jcr:primaryType="cq:PageContent"
-            jcr:title="Button Component Test Page"
-            sling:resourceType="core-components-examples/components/page">
-        <root
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="wcm/foundation/components/responsivegrid">
-            <responsivegrid
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="wcm/foundation/components/responsivegrid">
-                <button
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/button/v1/button"/>
-            </responsivegrid>
-        </root>
-    </jcr:content>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+  xmlns:cq="http://www.day.com/jcr/cq/1.0"
+  xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+  jcr:primaryType="cq:Page">
+  <jcr:content
+    cq:template="/conf/core-components-examples/settings/wcm/templates/content-page"
+    jcr:primaryType="cq:PageContent"
+    jcr:title="Button Component Test Page"
+    sling:resourceType="core-components-examples/components/page">
+    <root
+      jcr:primaryType="nt:unstructured"
+      sling:resourceType="wcm/foundation/components/responsivegrid">
+      <responsivegrid
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="wcm/foundation/components/responsivegrid">
+        <button
+          jcr:primaryType="nt:unstructured"
+          sling:resourceType="core/wcm/components/button/v1/button"/>
+      </responsivegrid>
+    </root>
+  </jcr:content>
 </jcr:root>

--- a/aem65/src/test/resources/testpages/core-components/buttonComponentTestPage.xml
+++ b/aem65/src/test/resources/testpages/core-components/buttonComponentTestPage.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="cq:Page">
+    <jcr:content
+            cq:template="/conf/core-components-examples/settings/wcm/templates/content-page"
+            jcr:primaryType="cq:PageContent"
+            jcr:title="Button Component Test Page"
+            sling:resourceType="core-components-examples/components/page">
+        <root
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wcm/foundation/components/responsivegrid">
+            <responsivegrid
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="wcm/foundation/components/responsivegrid">
+                <button
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="core/wcm/components/button/v1/button"/>
+            </responsivegrid>
+        </root>
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION
Button core component tests for Cognifide/bobcat#373. 
This component is currently not available under We Retail. Installation of test components example package is required to run these tests (available [here](https://github.com/adobe/aem-core-wcm-components/releases)). Test page is created under /content/core-components-examples/library/. 